### PR TITLE
NERCDL-1049 update minio image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM minio/minio:RELEASE.2021-04-27T23-46-03Z.release.0033eb96
+FROM minio/minio:RELEASE.2017-11-22T19-55-46Z
 
 LABEL maintainer="joshua.foster@stfc.ac.uk"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM minio/minio
+FROM minio/minio:RELEASE.2021-04-27T23-46-03Z.release.0033eb96
 
-LABEL maintainer "joshua.foster@stfc.ac.uk"
+LABEL maintainer="joshua.foster@stfc.ac.uk"
 
 RUN apk --no-cache add shadow su-exec
 


### PR DESCRIPTION
Be specific on minio image, and choose an image which should allow a reverse proxy to work, https://hub.docker.com/layers/minio/minio/RELEASE.2017-11-22T19-55-46Z/images/sha256-28cbd73844f89766512b2194198574b49582d6056dfb06e6738bda3744d7a473?context=explore ,
which corresponds to https://github.com/minio/minio/releases/tag/RELEASE.2017-11-22T19-55-46Z.